### PR TITLE
Weave + Latex

### DIFF
--- a/docs.sh
+++ b/docs.sh
@@ -11,9 +11,11 @@ if git tag | grep -q $1; then
   git fetch
   git checkout tags/$1
   echo "Checked out tag $1."
+  target=$1
 elif [ "$1" = "master" ]; then
   echo "You selected the master branch."
   git checkout master
+  target="dev"
 else
   echo "Sorry, you didn't pass in a valid tag."
   exit 1
@@ -32,14 +34,14 @@ git clone -b gh-pages --single-branch https://github.com/QuantEcon/SimpleDiffere
 echo "Cloned docs branch."
 
 # Pass files to docs repo
-mkdir -p SimpleDifferentialOperators.jl/$1/generated/
-mv docs/tex/discretized-differential-operator-derivation.pdf SimpleDifferentialOperators.jl/$1/generated/ # move PDF
+mkdir -p SimpleDifferentialOperators.jl/$target/generated/
+mv docs/tex/discretized-differential-operator-derivation.pdf SimpleDifferentialOperators.jl/$target/generated/ # move PDF
 echo "Copied PDF."
-mv docs/examples/*.ipynb SimpleDifferentialOperators.jl/$1/generated/ # move notebooks
+mv docs/examples/*.ipynb SimpleDifferentialOperators.jl/$target/generated/ # move notebooks
 echo "Copied example notebooks"
 
 # Git operations
-(cd SimpleDifferentialOperators.jl; git add -A; git commit -m "Add generated objects to $1 docs"; git push)
+(cd SimpleDifferentialOperators.jl; git add -A; git commit -m "Add generated objects to $target docs"; git push)
 echo "Carried out git operations."
 
 # Clean

--- a/docs.sh
+++ b/docs.sh
@@ -1,0 +1,45 @@
+# Exit if any command fails (since these only make sense in sequence, we'd get unpredictable behavior otherwise)
+set -e
+
+# Validate tag
+if git tag | grep -q $1; then
+  echo "You passed in a valid tag."
+else
+  echo "Sorry, you didn't pass in a valid tag."
+  exit 1
+fi
+
+# Stash any current changes.
+git stash
+
+# Checkout that tag (ensures that the right docs directory corresponds to the right tag)
+git fetch
+git checkout tags/$1
+echo "Checked out tag $1."
+
+# Weave examples
+(cd docs/examples && julia generate.jl) # weaves notebooks to docs/examples. requires weave to be installed
+echo "Weaved example notebooks."
+
+# Run pdflatex steps
+(cd docs/tex && pdflatex discretized-differential-operator-derivation.tex) # compiled pdf to docs/tex
+echo "Compiled PDF."
+
+# Clone gh-pages branch
+git clone -b gh-pages --single-branch https://github.com/QuantEcon/SimpleDifferentialOperators.jl
+echo "Cloned docs branch."
+
+# Pass files to docs repo
+mkdir -p SimpleDifferentialOperators.jl/$1/generated/
+mv docs/tex/discretized-differential-operator-derivation.pdf SimpleDifferentialOperators.jl/$1/generated/ # move PDF
+echo "Copied PDF."
+mv docs/examples/*.ipynb SimpleDifferentialOperators.jl/$1/generated/ # move notebooks
+echo "Copied example notebooks"
+
+# Git operations
+(cd SimpleDifferentialOperators.jl; git add -A; git commit -m "Add generated objects to $1 docs --- $date"; git push)
+echo "Carried out git operations."
+
+# Clean
+rm -rf SimpleDifferentialOperators.jl
+echo "Cleaned."

--- a/docs.sh
+++ b/docs.sh
@@ -1,21 +1,23 @@
 # Exit if any command fails (since these only make sense in sequence, we'd get unpredictable behavior otherwise)
 set -e
 
+# Stash any current changes.
+git stash
+
 # Validate tag
 if git tag | grep -q $1; then
   echo "You passed in a valid tag."
+  # Checkout that tag (ensures that the right docs directory corresponds to the right tag)
+  git fetch
+  git checkout tags/$1
+  echo "Checked out tag $1."
+elif [ "$1" = "master" ]; then
+  echo "You selected the master branch."
+  git checkout master
 else
   echo "Sorry, you didn't pass in a valid tag."
   exit 1
 fi
-
-# Stash any current changes.
-git stash
-
-# Checkout that tag (ensures that the right docs directory corresponds to the right tag)
-git fetch
-git checkout tags/$1
-echo "Checked out tag $1."
 
 # Weave examples
 (cd docs/examples && julia generate.jl) # weaves notebooks to docs/examples. requires weave to be installed

--- a/docs.sh
+++ b/docs.sh
@@ -37,7 +37,7 @@ mv docs/examples/*.ipynb SimpleDifferentialOperators.jl/$1/generated/ # move not
 echo "Copied example notebooks"
 
 # Git operations
-(cd SimpleDifferentialOperators.jl; git add -A; git commit -m "Add generated objects to $1 docs --- $date"; git push)
+(cd SimpleDifferentialOperators.jl; git add -A; git commit -m "Add generated objects to $1 docs"; git push)
 echo "Carried out git operations."
 
 # Clean

--- a/docs/examples/example.jmd
+++ b/docs/examples/example.jmd
@@ -1,0 +1,16 @@
+Here's one bit of code
+
+```julia
+x = 1
+y = 2.3
+@show x + y
+x + y ≈ 3.3
+```
+
+And here's another
+
+```julia
+using Pkg
+pkg"activate ../.."
+using SimpleDifferentialOperators
+```

--- a/docs/examples/example2.jmd
+++ b/docs/examples/example2.jmd
@@ -1,0 +1,7 @@
+Here's another bit of code
+
+```julia
+foo(x) = x + one(x)
+foo(2)
+foo(2.3)
+```

--- a/docs/examples/generate.jl
+++ b/docs/examples/generate.jl
@@ -1,0 +1,6 @@
+using Weave
+fileset = readdir(@__DIR__)
+for file in fileset
+    occursin(".jmd", file) && Weave.notebook(file, @__DIR__)
+    println("Weaved $file")
+end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,7 @@ makedocs(sitename = "SimpleDifferentialOperators.jl",
         "index.md",
         "formula.md",
         "api.md",
+		"notebooks.md"
     ],
 	doctest = :fix)
 

--- a/docs/src/formula.md
+++ b/docs/src/formula.md
@@ -43,4 +43,4 @@ L_2 \equiv \frac{1}{\Delta^2}\begin{pmatrix}
 
 which represent the backward first order, foward first order, and central second order differential operators respectively.
 
-Derivation, including formula for irregular grids, can be found [here](https://github.com/QuantEcon/SimpleDifferentialOperators.jl/blob/master/docs/tex/discretized-differential-operator-derivation.pdf).
+Derivation, including formula for irregular grids, can be found [here](../generated/discretized-differential-operator-derivation.pdf).

--- a/docs/src/notebooks.md
+++ b/docs/src/notebooks.md
@@ -1,0 +1,4 @@
+Notebooks
+==============
+
+See [here](../generated/) for a gallery of example notebooks using this package to solve economic problems. 


### PR DESCRIPTION
@jlperla Here is the workflow: 

1. Tag a new release. The examples live in `docs/examples`. 
2. Wait for the `Documenter.jl` interaction with the `gh-pages` branch to finish (i.e., there shouldn't be any pending jobs on Travis). 
3. From a Linux/Mac machine, run `./docs.sh v0.3.0` (or whatever the tag is). 

To see the results, here's [a commit](https://github.com/QuantEcon/SimpleDifferentialOperators.jl/commit/f07975b1f58037adc26c97ca2905ab7d4e318df4) the script checked in for the `v0.2.1` version. 

In terms of things to review, it's mainly the `docs.sh` script. 

This requires a computer that's setup properly (i.e., `Weave.jl` is installed, `pdflatex` and `jupyter nbconvert` are valid commands), but I figured the cost/benefit of catching/fixing those errors wasn't worth it. 
