### PR TITLE
Use $f$ instead of $v$ or $g$ for distribution

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,7 +19,7 @@ Detailed derivations and more applications can be found [here](generated/discret
 Consider solving for `v` from the following equation by the Hamilton-Jacobi-Bellman equation (HJBE):
 
 ```math
-\rho v(x) = f(x) + \mu \partial_x v(x) + \frac{\sigma^2}{2} \partial_{xx} v(x)
+\rho v(x) = \pi(x) + \mu \partial_x v(x) + \frac{\sigma^2}{2} \partial_{xx} v(x)
 ```
 
 for some constant $\rho, \sigma > 0$ and $\mu \leq 0$. To solve `v` under the reflecting barrier conditions $v'(0) = v'(1) = 0$ on `M`-size discretized grids, one can run the following code:
@@ -27,7 +27,7 @@ for some constant $\rho, \sigma > 0$ and $\mu \leq 0$. To solve `v` under the re
 ```julia
 using LinearAlgebra, SimpleDifferentialOperators
 # setup
-f(x) = x^2
+π(x) = x^2
 μ = -0.1 # constant negative drift
 σ = 0.1
 ρ = 0.05
@@ -43,7 +43,7 @@ Lₓ = μ*L₁₋bc(x̄, bc) + σ^2 / 2 * L₂bc(x̄, bc)
 L_bc = I * ρ - Lₓ
 
 # solve the value function
-v = L_bc \ f.(x)
+v = L_bc \ π.(x)
 ```
 
 Note that the interior solution `v` does not the values of $v$ at the boundary, i.e., $v(0)$ and $v(1)$. To extend the interior solution to the boundary points, one can call `extrapolatetoboundary` as follows:
@@ -78,7 +78,7 @@ b = [0.0; 0.0]
 L = [spzeros(M) ρ*I spzeros(M)] - Lₓ
 
 # stack the systems of bellman and boundary conditions, and solve
-v̄ = [L; B] \ [f.(x); b]
+v̄ =  [L; B] \ [π.(x); b]
 
 # extract the interior (is identical with `v` above)
 v =  v̄[2:end-1]
@@ -91,7 +91,7 @@ First, consider the case where $S \neq 0$, which gives a nonhomogenous boundary 
 
 ```julia
 # define S
-S = 0.0
+S = 3.0
 
 # boundary conditions (i.e. B v̄ = b)
 B = transpose([[1; 0; zeros(M)] [zeros(M); -1; 1]])
@@ -107,28 +107,28 @@ B[:,2]
 \end{bmatrix}
 =
 \begin{bmatrix}
-f^*
+π^*
 b[:,2]
 \end{bmatrix}
 ```
 where
 
 ```math
-f^* =
+π^* =
 \begin{bmatrix}
-f(x_1) - S(s\mu \Delta^{-1} - (\sigma^2/2) \Delta^{-2})
+π(x_1) - S(s\mu \Delta^{-1} - (\sigma^2/2) \Delta^{-2})
 \\ 
 \vdots
 \\
-f(x_{M})
+π(x_{M})
 \end{bmatrix}
 ```
 
 Now solve `v`:
 ```julia
 # stack the systems of bellman and boundary conditions, and solve
-v̄ = [L; B] \ [f.(x); b]
-``` 
+v̄ =  [L; B] \ [π.(x); b]
+```
 
 Here is a plot for `v`:
 
@@ -147,7 +147,7 @@ Lₓ = μ*L₁₋bc(x̄, bc) + σ^2 / 2 * L₂bc(x̄ , bc)
 L_bc = I * ρ - Lₓ
 
 # solve the value function
-v = L_bc \ f.(x)
+v = L_bc \ π.(x)
 ```
 
 In fact, on the interior, they return identical solutions:
@@ -160,7 +160,7 @@ B = transpose([[1; 0; zeros(M)] [zeros(M); -1; 1]])
 b = [S; 0.0];
 
 # stack the systems of bellman and boundary conditions, and solve
-v̄ = [L; B] \ [f.(x); b]
+v̄ = [L; B] \ [π.(x); b]
 
 # confirm that v returns the identical solution as the one from the stacked system
 using Test
@@ -172,7 +172,7 @@ using Test
 -------------
 One can also deploy upwind schemes when drift variable is not constant. Consider solving for `v` from the following Bellman equation:
 ```math
-\rho v(x) = f(x) + \mu(x) \partial_x v(x) + \frac{\sigma^2}{2} \partial_{xx} v(x)
+\rho v(x) = π(x) + \mu(x) \partial_x v(x) + \frac{\sigma^2}{2} \partial_{xx} v(x)
 ```
 
 associated with the diffusion process
@@ -184,7 +184,7 @@ for some constant $\rho, \sigma > 0$ and $\mu(x) = -x$. Note that $\mu(x)$ depen
 
 ```julia
 # setup
-f(x) = x^2
+π(x) = x^2
 μ(x) = -x # drift depends on state
 σ = 1.0
 ρ = 0.05
@@ -203,7 +203,7 @@ Lₓ = L₁ - σ^2 / 2 * L₂bc(x̄, bc)
 L_bc_state_dependent = I * ρ - Lₓ
 
 # solve the value function
-v = L_bc_state_dependent \ f.(x)
+v = L_bc_state_dependent \ π.(x)
 ```
 
 ### Finding stationary distribution from the Kolmogorov forward equation (KFE)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -209,14 +209,15 @@ v = L_bc_state_dependent \ π.(x)
 ### Finding stationary distribution from the Kolmogorov forward equation (KFE)
 -------------
 The KFE equation is
-$$
-\partial_t v(x,t) = -\mu \partial_{x} v(x,t) + \frac{\sigma^2}{2} \partial_{xx} v(x,t)
-$$
+```math
+\partial_t f(x,t) = -\mu \partial_{x} f(x,t) + \frac{\sigma^2}{2} \partial_{xx} f(x,t)
+```
+
 for $x \in (x_{\min}, x_{\max})$ with the following corresponding reflecting barrier conditions:
 ```math
 \begin{align}
--\mu v(x_{\min}, t) +\frac{\sigma^2}{2} \partial_{x} v(x_{\min}, t) &= 0 \\
--\mu v(x_{\max}, t) +\frac{\sigma^2}{2} \partial_{x} v(x_{\max}, t) &= 0
+-\mu f(x_{\min}, t) +\frac{\sigma^2}{2} \partial_{x} f(x_{\min}, t) &= 0 \\
+-\mu f(x_{\max}, t) +\frac{\sigma^2}{2} \partial_{x} f(x_{\max}, t) &= 0
 \end{align}
 ```
 
@@ -224,16 +225,16 @@ i.e.,
 
 ```math
 \begin{align}
--\frac{2\mu}{\sigma^2} v(x_{\min}, t) +\partial_{x} v(x_{\min}, t) &= 0 \\
--\frac{2\mu}{\sigma^2} v(x_{\max}, t) +\partial_{x} v(x_{\max}, t) &= 0
+-\frac{2\mu}{\sigma^2} f(x_{\min}, t) +\partial_{x} f(x_{\min}, t) &= 0 \\
+-\frac{2\mu}{\sigma^2} f(x_{\max}, t) +\partial_{x} f(x_{\max}, t) &= 0
 \end{align}
 ```
 
 which gives mixed boundary conditions with $\overline{\xi} = \underline{\xi} = -\frac{2\mu}{\sigma^2}$.
 
-One can compute the stationary distribution of the state `x` above from the corresponding KFE by taking $\partial_{t} g(x,t) = 0$, i.e., solving $g$ from the $L^* g(x) = 0$ where
+One can compute the stationary distribution of the state `x` above from the corresponding KFE by taking $\partial_{t} f(x,t) = 0$, i.e., solving $f$ from the $L^* f(x) = 0$ where
 ```math
-L^* = - \mu(x) \partial_{x} + \frac{\sigma^2}{2} \partial_{xx}
+L^* = - \mu \partial_{x} + \frac{\sigma^2}{2} \partial_{xx}
 ```
 
 The following code constructs $L^*$:
@@ -258,13 +259,13 @@ bc = (Mixed(ξ = ξ_lb, direction = :backward), Mixed(ξ = ξ_ub))
 L_KFE = Array(-μ*L₁₊bc(x̄, bc) + σ^2 / 2 * L₂bc(x̄, bc))
 ```
 
-One can find the stationary distribution $g$ by solving the following discretized system of equations:
+One can find the stationary distribution $f$ by solving the following discretized system of equations:
 
 ```math
-L^* g = 0
+L^* f = 0
 ```
 
-such that the sum of $g$ is one. This can be found by finding a non-trivial eigenvector `g_ss` for `L_KFE` associated with the eigenvalue of zero:
+such that the sum of $f$ is one. This can be found by finding a non-trivial eigenvector `f_ss` for `L_KFE` associated with the eigenvalue of zero:
 
 ```julia
 using Arpack # library for extracting eigenvalues and eigenvectors
@@ -272,16 +273,16 @@ using Arpack # library for extracting eigenvalues and eigenvectors
 # extract eigenvalues and eigenvectors, smallest eigenval in magintute first
 λ, ϕ = eigs(L_KFE, which = :SM); 
 # extract the very first eigenvector (associated with the smallest eigenvalue)
-g_ss = real.(ϕ[:,1]);
+f_ss = real.(ϕ[:,1]);
 # normalize it
-g_ss = g_ss / sum(g_ss)
+f_ss = f_ss / sum(f_ss)
 ```
 
 Using `L` from the state-dependent drift example above, this results in the following stationary distribution:
 
 ```julia
-plot(x, g_ss, lw = 4, label = "g_ss")
-```g
+plot(x, f_ss, lw = 4, label = "f_ss")
+```
 
 ![plot-stationary-dist](assets/plot-stationary-dist.png)
 


### PR DESCRIPTION
Resolves #153 